### PR TITLE
Adding some CI with Flake8

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,16 @@
+name: Flake8
+on: pull_request
+jobs:
+    flake8:
+        name: Check code with Flake8
+        runs-on: ubuntu-20.04
+        container: fedora:34
+        steps:
+            - name: Install Pipenv and Git
+                run: dnf install -y pipenv git
+            - name: Checkout code
+                uses: actions/checkout@v2
+            - name: Setup environment
+                run: pipenv sync --dev
+            - name: Run Flake8
+                run: pipenv run flake8 --max-line-length 120

--- a/.github/workflows/flake8.yml.bak
+++ b/.github/workflows/flake8.yml.bak
@@ -7,10 +7,10 @@ jobs:
         container: fedora:34
         steps:
             - name: Install Pipenv and Git
-              run: dnf install -y pipenv git
+                run: dnf install -y pipenv git
             - name: Checkout code
-              uses: actions/checkout@v2
+                uses: actions/checkout@v2
             - name: Setup environment
-              run: pipenv sync --dev
+                run: pipenv sync --dev
             - name: Run Flake8
-              run: pipenv run flake8 --max-line-length 120
+                run: pipenv run flake8 --max-line-length 120

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Vagrant
 .vagrant
+
+# Addition from part 3- task 9 commiting
+nohup.out

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 django = "*"
 
 [dev-packages]
+flake8 = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c36ae28fea7b9a4cc02145632e2f41469af2e7b38b801903abb8333d3306f36b"
+            "sha256": "bfea4da904cc0f6850b128b9d33331e8f854844bdd80edaa087f71f26391284c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,5 +41,37 @@
             "version": "==0.4.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
+        }
+    }
 }


### PR DESCRIPTION
We set up GitHub actions to run flake8 on the code as we submit new PRs.The GitHub actions
configuration files reside in the .github/workflows/flake8.yml

We’re going to be adding some Python code to our repository, so we’d like to at least be able to
verify that the code we add conforms to proper Python syntax and coding standards. To do this
we will use the “Flake8” tool and set things up so that it scans our code automatically as we
send PRs and provides feedback on the PR review screen